### PR TITLE
Create Installation Directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ pam_krb5_cc_move.so: src/pam_krb5_cc_move.o
 install: all
 	install -d $(DESTDIR)$(MANDIR)/man8
 	install -p -m 0644 man/pam_krb5_cc_move.8 $(DESTDIR)$(MANDIR)/man8/pam_krb5_cc_move.8
+	install -d $(DESTDIR)$(MANDIR)/$(INSTALLDIR)
 	install -p -m 0755 pam_krb5_cc_move.so $(DESTDIR)/$(INSTALLDIR)/pam_krb5_cc_move.so 
 
 clean:


### PR DESCRIPTION
The lib installation directory should be created before the pam module is installed to it.